### PR TITLE
Prefix the command with exec so that the process responds appropriately to systemctl

### DIFF
--- a/honcho_export_systemd/templates/systemd/process.service
+++ b/honcho_export_systemd/templates/systemd/process.service
@@ -7,7 +7,7 @@ WorkingDirectory={{ app_root }}
 {% for k, v in process.env.items() -%}
 Environment={{ k }}={{ v | shellquote }}
 {% endfor -%}
-ExecStart={{ shell }} -c '{{ process.cmd }}'
+ExecStart={{ shell }} -lc 'exec {{ process.cmd }}'
 Restart=always
 StandardInput=null
 StandardOutput=syslog


### PR DESCRIPTION
This is inline with what is done with `foreman`'s `systemd` export at https://github.com/ddollar/foreman/commit/90fdf3512e3d18e9e631147d11212aca93b5f430.